### PR TITLE
Added boolean property for sticky view

### DIFF
--- a/APParallaxHeader/UIScrollView+APParallaxHeader.h
+++ b/APParallaxHeader/UIScrollView+APParallaxHeader.h
@@ -42,6 +42,7 @@ typedef NS_ENUM(NSUInteger, APParallaxTrackingState) {
 @property (nonatomic, strong) APParallaxShadowView *shadowView;
 @property (nonatomic) CGFloat minimumHeight;
 @property (nonatomic) BOOL automaticallyAdjustScrollIndicatorInsets;
+@property (nonatomic) BOOL sticky;
 
 - (id)initWithFrame:(CGRect)frame andShadow:(BOOL)shadow;
 

--- a/APParallaxHeader/UIScrollView+APParallaxHeader.m
+++ b/APParallaxHeader/UIScrollView+APParallaxHeader.m
@@ -298,6 +298,9 @@ static char UIScrollViewParallaxView;
         CGRect newFrame = CGRectMake(0, contentOffset.y, CGRectGetWidth(self.frame), yOffset);
         if (self.minimumHeight > 0.f) {
             newFrame.size.height = MAX(newFrame.size.height, self.minimumHeight);
+	    if(contentOffset.y > -1 * _minimumHeight) {
+                newFrame.origin.y = newFrame.origin.y - contentOffset.y - _minimumHeight;
+            }
         }
         [self setFrame:newFrame];
     }

--- a/APParallaxHeader/UIScrollView+APParallaxHeader.m
+++ b/APParallaxHeader/UIScrollView+APParallaxHeader.m
@@ -286,19 +286,19 @@ static char UIScrollViewParallaxView;
 
 - (void)scrollViewDidScroll:(CGPoint)contentOffset {
     // We do not want to track when the parallax view is hidden
-    /*if (contentOffset.y > 0) {
+    if (!_sticky && contentOffset.y > 0) {
         [self setState:APParallaxTrackingInactive];
     } else {
         [self setState:APParallaxTrackingActive];
     }
-    */
+    
     if(self.state == APParallaxTrackingActive) {
         CGFloat yOffset = contentOffset.y*-1;
         
         CGRect newFrame = CGRectMake(0, contentOffset.y, CGRectGetWidth(self.frame), yOffset);
         if (self.minimumHeight > 0.f) {
             newFrame.size.height = MAX(newFrame.size.height, self.minimumHeight);
-	    if(contentOffset.y > -1 * _minimumHeight) {
+            if(!_sticky && contentOffset.y > -1 * _minimumHeight) {
                 newFrame.origin.y = newFrame.origin.y - contentOffset.y - _minimumHeight;
             }
         }

--- a/APParallaxHeader/UIScrollView+APParallaxHeader.m
+++ b/APParallaxHeader/UIScrollView+APParallaxHeader.m
@@ -286,7 +286,7 @@ static char UIScrollViewParallaxView;
 
 - (void)scrollViewDidScroll:(CGPoint)contentOffset {
     // We do not want to track when the parallax view is hidden
-    if (!_sticky && contentOffset.y > 0) {
+    if (_sticky || contentOffset.y > 0) {
         [self setState:APParallaxTrackingInactive];
     } else {
         [self setState:APParallaxTrackingActive];


### PR DESCRIPTION
Min height changes forced parallax view to be sticky. Using parallax view as the header for WKWebView sometimes creates the need for a min height without sticky, so I added a sticky property.